### PR TITLE
fix: return nil on successful certificate deletion across all CAs (#97)

### DIFF
--- a/ca/functions.go
+++ b/ca/functions.go
@@ -377,7 +377,7 @@ func (h *CAFunctionHandler) DeleteCertificatesAllCA(keyID string) error {
 		if _, is := err.(*cmn.NotFoundError); is {
 			log.WithError(err).WithField("caID", keyID).Debugf("Provider '%s' not managing "+
 				"key '%s', this is normal.", id, keyID)
-		} else {
+		} else if err != nil {
 			return fmt.Errorf("problems deleting key '%s' in ca '%s', %w", id, keyID, err)
 		}
 	}

--- a/ca/functions_test.go
+++ b/ca/functions_test.go
@@ -1,0 +1,108 @@
+package ca
+
+import (
+	"time"
+
+	"testing"
+
+	"github.com/dns3l/dns3l-core/ca/types"
+	"github.com/dns3l/dns3l-core/renew"
+	authtypes "github.com/dns3l/dns3l-core/service/auth/types"
+	"github.com/dns3l/dns3l-core/util"
+)
+
+// fakeCAProvider is a minimal types.CAProvider whose certificate operations all
+// succeed, so DeleteCertificate completes without error.
+type fakeCAProvider struct{}
+
+func (p *fakeCAProvider) Init(types.ProviderConfigurationContext) error { return nil }
+func (p *fakeCAProvider) GetInfo() *types.CAProviderInfo                { return &types.CAProviderInfo{} }
+func (p *fakeCAProvider) IsEnabled() bool                               { return true }
+func (p *fakeCAProvider) PrecheckClaimCertificate(*types.CertificateClaimInfo) error {
+	return nil
+}
+func (p *fakeCAProvider) ClaimCertificate(*types.CertificateClaimInfo) error { return nil }
+func (p *fakeCAProvider) RenewCertificate(*types.CertificateRenewInfo) error { return nil }
+func (p *fakeCAProvider) RevokeCertificate(string, *types.CACertInfo) error  { return nil }
+func (p *fakeCAProvider) CleanupAfterDeletion(string, *types.CACertInfo) error {
+	return nil
+}
+
+// fakeStateManager / fakeSession provide a state backend in which the requested
+// certificate exists and is deleted without error.
+type fakeStateManager struct{}
+
+func (m *fakeStateManager) NewSession() (types.CAStateManagerSession, error) {
+	return &fakeSession{}, nil
+}
+
+type fakeSession struct{}
+
+func (s *fakeSession) Close() error { return nil }
+
+func (s *fakeSession) GetCACertByID(keyID string, caID string) (*types.CACertInfo, error) {
+	return &types.CACertInfo{Name: keyID}, nil
+}
+
+func (s *fakeSession) DelCACertByID(keyID string, caID string) error { return nil }
+
+func (s *fakeSession) ListCACerts(string, string, []string, string,
+	*util.PaginationInfo) ([]types.CACertInfo, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) PutCACertData(string, string, *types.CACertInfo, string, string) error {
+	panic("not used in this test")
+}
+func (s *fakeSession) UpdateCACertData(string, string, time.Time, time.Time, time.Time,
+	time.Time, string, string) error {
+	panic("not used in this test")
+}
+func (s *fakeSession) GetResource(string, string, bool, string) (string, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) GetResources(string, string, bool, ...string) ([]string, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) GetNumberOfCerts(string, bool, time.Time) (uint, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) DeleteCertAllCA(string) error { panic("not used in this test") }
+func (s *fakeSession) ListExpired(time.Time, uint) ([]types.CertificateRenewInfo, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) ListToRenew(time.Time, uint) ([]types.CertificateRenewInfo, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) GetDomains(string, string) ([]string, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) UserHasCerts(*authtypes.UserInfo, string) (bool, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) GetLastRenewSummary() (*renew.ServerInfoRenewal, error) {
+	panic("not used in this test")
+}
+func (s *fakeSession) PutLastRenewSummary(*renew.ServerInfoRenewal) error {
+	panic("not used in this test")
+}
+
+// TestDeleteCertificatesAllCASucceeds is a regression test for issue #97:
+// a successful deletion must return a nil error. Previously the loop fell into
+// the failure branch on a nil error and returned fmt.Errorf(..., nil), i.e. a
+// non-nil error wrapping nil, so the DELETE endpoint reported failure on success.
+func TestDeleteCertificatesAllCASucceeds(t *testing.T) {
+	cfg := &Config{
+		Providers: map[string]*ProviderInfo{
+			"test-ca": {Type: "fake", Prov: &fakeCAProvider{}},
+		},
+	}
+	h := &CAFunctionHandler{
+		Config: cfg,
+		State:  &fakeStateManager{},
+	}
+
+	err := h.DeleteCertificatesAllCA("test-key")
+	if err != nil {
+		t.Fatalf("expected nil error on successful deletion, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `DELETE /api/v1/crt/<cert>` returned a failure even when the certificate was deleted successfully (#97).
- Root cause is in `CAFunctionHandler.DeleteCertificatesAllCA` (`ca/functions.go`). The loop classified the result of `DeleteCertificate` by type-asserting it against `*common.NotFoundError`:

  ```go
  if _, is := err.(*cmn.NotFoundError); is {
      // provider not managing this key — normal, log and continue
  } else {
      return fmt.Errorf("problems deleting key '%s' in ca '%s', %w", id, keyID, err)
  }
  ```

  On a successful deletion `DeleteCertificate` returns a `nil` error. A `nil` error is not a `*NotFoundError`, so the type assertion fails (`is == false`) and execution fell into the `else` branch, returning `fmt.Errorf(..., %w, nil)` — a non-nil error that wraps `nil`. The endpoint therefore reported failure on every successful delete, and the loop also bailed out after the first provider instead of continuing to the rest.

## Changes

- `ca/functions.go`: guard the failure branch with `err != nil` (`} else {` → `} else if err != nil {`). A `NotFoundError` is still logged as normal, a genuine non-nil error is still wrapped and returned, and a successful (`nil`) result now correctly falls through so the loop continues and the function returns `nil`.
- `ca/functions_test.go`: add `TestDeleteCertificatesAllCASucceeds`, a regression test that drives `DeleteCertificatesAllCA` through a successful deletion (via minimal fakes implementing the public `types.CAProvider` and `types.CAStateManager` interfaces) and asserts a `nil` error is returned. Verified the test fails on the pre-fix source (`problems deleting key ... %!w(<nil>)`) and passes with the fix.

Fixes #97